### PR TITLE
[feature #163628730] Endpoint to view one office

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,15 @@
-language: node_js
-
-node_js:
-  - "node"
-
+# single test suite, non-parallel build.
 env:
   global:
     - CC_TEST_REPORTER_ID=760492325fe8c72993fc835a57e9849e657a1d773b590f91ea77b5a132ad5b7b
-
-dist: trusty
-
-addons:
-  chrome: stable
-
-  before_script:
-  - yarn global add nyc
+language: node_js
+node_js:
+  - "node"
+before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-
 script:
-  - nyc --reporter=lcov yarn run unit
-
+  - bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-
-notifications:
-  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,23 @@ node_js:
 env:
   global:
     - CC_TEST_REPORTER_ID=760492325fe8c72993fc835a57e9849e657a1d773b590f91ea77b5a132ad5b7b
+
+dist: trusty
+
+addons:
+  chrome: stable
+
+  before_script:
+  - yarn global add nyc
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+script:
+  - nyc --reporter=lcov yarn run unit
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,3 @@ env:
 language: node_js
 node_js:
   - "node"
-before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
-script:
-  - bundle exec rspec
-after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,21 @@
-# single test suite, non-parallel build.
-env:
-  global:
-    - CC_TEST_REPORTER_ID=760492325fe8c72993fc835a57e9849e657a1d773b590f91ea77b5a132ad5b7b
 language: node_js
 node_js:
   - "node"
+
+notifications:
+  email: false
+
+env:
+  global:
+    - CC_TEST_REPORTER_ID=760492325fe8c72993fc835a57e9849e657a1d773b590f91ea77b5a132ad5b7b
+
+before_script:
+  - npm install nyc
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+script:
+  - nyc --reporter=lcov --reporter=text-lcov npm test
+
+after_success:
+  npm run coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -4149,6 +4149,12 @@
         }
       }
     },
+    "mocha-lcov-reporter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
+      "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "coveralls": "nyc --reporter=lcov --reporter=text-lcov npm test",
-    "test": "mocha --report progress --require babel-register \"server/**/*.test.js\" --exit",
-    "test:coverage": "nyc --reporter=html --reporter=text mocha --require babel-register \"server/**/*.test.js\" --exit",
     "start": "babel-node ./server/app.js",
-    "start:dev": "nodemon ./server/app.js  --exec babel-node --"
+    "start:dev": "nodemon ./server/app.js  --exec babel-node --",
+    "test": "set NODE_ENV=test&& nyc --reporter=html --reporter=text mocha --require babel-register --timeout 10000 \"server/**/*.test.js\" --exit"
   },
   "repository": {
     "type": "git",
@@ -40,6 +39,7 @@
     "eslint": "^5.12.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.16.0",
+    "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^13.1.0"
   }
 }

--- a/server/controllers/offices.js
+++ b/server/controllers/offices.js
@@ -46,6 +46,22 @@ class offices {
       data: officesDb,
     });
   }
+
+  // READ - Get a particular office
+  static getOne(req, res) {
+    const id = parseInt(req.params.id, 10);
+    const selectedOffice = officesDb.find(office => office.id === id);
+    if (!selectedOffice) {
+      return res.status(404).json({
+        status: '404',
+        error: 'The office was not found',
+      });
+    }
+    return res.status(200).json({
+      status: 200,
+      data: [selectedOffice],
+    });
+  }
 }
 
 export default offices;

--- a/server/routes/offices.js
+++ b/server/routes/offices.js
@@ -5,6 +5,6 @@ const router = Express.Router();
 
 router.post('/', offices.create);
 router.get('/', offices.getAll);
-
+router.get('/:id', offices.getOne);
 
 export default router;

--- a/server/test/offices.test.js
+++ b/server/test/offices.test.js
@@ -13,7 +13,6 @@ chai.should();
 describe('Offices', () => {
   it('should CREATE a SINGLE office on /offices POST', (done) => {
     const newOffice = {
-      id: 1,
       type: 'state',
       name: 'governor of kogi',
     };
@@ -25,6 +24,20 @@ describe('Offices', () => {
         res.body.should.have.property('status').eql(201);
         res.body.should.be.a('object');
         res.body.data.should.be.a('array');
+        done(err);
+      });
+  });
+  it('should NOT create if office already exists on /offices POST', (done) => {
+    const newOffice = {
+      type: 'federal',
+      name: 'president',
+    };
+    chai.request(app)
+      .post('/api/v1/politico/offices')
+      .send(newOffice)
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.body.should.have.property('status').eql(400);
         done(err);
       });
   });
@@ -47,10 +60,39 @@ describe('Offices', () => {
       .get('/api/v1/politico/offices')
       .end((err, res) => {
         res.should.have.status(200);
+        res.should.not.have.status(404);
         res.body.data.should.be.a('array');
         res.body.data[0].should.have.property('id');
         res.body.data[0].should.have.property('name');
         res.body.data[0].should.have.property('type');
+        done();
+      });
+  });
+  it('should LIST a SINGLE office on /offices/<id> GET', (done) => {
+    const id = 1;
+    chai.request(app)
+      .get(`/api/v1/politico/offices/${id}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.should.not.have.status(404);
+        res.body.data.should.be.a('array');
+        res.body.data.should.not.be.a('object');
+        res.body.data[0].should.have.property('id');
+        res.body.data[0].should.have.property('name');
+        res.body.data[0].should.have.property('type');
+        res.body.data[0].id.should.equal(id);
+        res.body.should.not.have.property('error');
+        done();
+      });
+  });
+  it('should NOT list a SINGLE office on /offices/<id> GET', (done) => {
+    const id = 6;
+    chai.request(app)
+      .get(`/api/v1/politico/offices/${id}`)
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.be.a('object');
+        res.body.should.have.property('error');
         done();
       });
   });

--- a/server/test/parties.test.js
+++ b/server/test/parties.test.js
@@ -28,6 +28,22 @@ describe('Parties', () => {
         done(err);
       });
   });
+  it('should NOT CREATE if party already exists on /parties POST', (done) => {
+    const newParty = {
+      name: 'peoples democratic party',
+      hqAddress: 'abuja, nigeria',
+      logoUrl: 'link',
+    };
+    chai.request(app)
+      .post('/api/v1/politico/parties')
+      .send(newParty)
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.body.should.have.property('error');
+        res.body.should.have.property('status').eql(400);
+        done(err);
+      });
+  });
 
   const nameOmitted = {
     hqAddress: 'Abuja, Nigeria',
@@ -41,7 +57,7 @@ describe('Parties', () => {
     name: 'PDP',
     hqAddress: 'Abuja, Nigeria',
   };
-  it('should NOT create party if NAME field is OMITTED', (done) => {
+  it('should NOT CREATE party if NAME field is OMITTED', (done) => {
     chai.request(app)
       .post('/api/v1/politico/parties')
       .send(nameOmitted)
@@ -51,7 +67,7 @@ describe('Parties', () => {
         done(err);
       });
   });
-  it('should NOT create party if ADDRESS field is OMITTED', (done) => {
+  it('should NOT CREATE party if ADDRESS field is OMITTED', (done) => {
     chai.request(app)
       .post('/api/v1/politico/parties')
       .send(addressOmitted)
@@ -61,7 +77,7 @@ describe('Parties', () => {
         done(err);
       });
   });
-  it('should NOT create party if LOGOUrl field is OMITTED', (done) => {
+  it('should NOT CREATE party if LOGOUrl field is OMITTED', (done) => {
     chai.request(app)
       .post('/api/v1/politico/parties')
       .send(logoUrlOmitted)
@@ -84,6 +100,17 @@ describe('Parties', () => {
         done();
       });
   });
+  it('should NOT LIST a single party on /parties/<id> GET', (done) => {
+    const id = 999;
+    chai.request(app)
+      .get(`/api/v1/politico/parties/${id}`)
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.be.a('object');
+        res.body.should.have.property('error');
+        done();
+      });
+  });
   it('should LIST a SINGLE party on /parties/<id> GET', (done) => {
     const id = 1;
     chai.request(app)
@@ -96,6 +123,56 @@ describe('Parties', () => {
         res.body.data[0].should.have.property('hqAddress');
         res.body.data[0].should.have.property('logoUrl');
         res.body.data[0].id.should.equal(id);
+        done();
+      });
+  });
+  it('should NOT UPDATE a party on /parties/<id> PUT', (done) => {
+    const id = 999;
+    chai.request(app)
+      .put(`/api/v1/politico/parties/${id}`)
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.be.a('object');
+        res.body.should.have.property('error');
+        done();
+      });
+  });
+  it('should UPDATE a single party on /parties/<id> PUT', (done) => {
+    const id = 1;
+    chai.request(app)
+      .put(`/api/v1/politico/parties/${id}`)
+      .send({ name: 'pdp' })
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.be.a('object');
+        res.body.should.have.property('data');
+        res.body.data[0].should.have.property('id');
+        res.body.data[0].should.have.property('name').equal('pdp');
+        res.body.data[0].should.have.property('hqAddress');
+        res.body.data[0].should.have.property('logoUrl');
+        done();
+      });
+  });
+  it('should NOT DELETE a party on /parties/<id> DELETE', (done) => {
+    const id = 999;
+    chai.request(app)
+      .delete(`/api/v1/politico/parties/${id}`)
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.be.a('object');
+        res.body.should.have.property('error');
+        done();
+      });
+  });
+  it('should DELETE a single party on /parties/<id> DELETE', (done) => {
+    const id = 1;
+    chai.request(app)
+      .delete(`/api/v1/politico/parties/${id}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.be.a('object');
+        res.body.should.have.property('data');
+        res.body.data[0].should.have.property('message');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Admin can view a single office

#### Description of Task to be completed?
`GET /api/politico/v1/office/:id`

#### How should this be manually tested?

- First clone the project on your local computer. 
- To do that create a folder in your local machine, open the terminal in that folder and run `https://github.com/ibkadeeko/Politico.git`
- cd into the project on your terminal and run `npm install` to install all dependencies
- start the server by running `npm start`

Using Postman test the endpoint above
- Make a GET request to http://localhost:3000/api/v1/politico/offices/:id

-Using Mocha run `npm test` or `npm run test:coverage`

#### What are the relevant pivotal tracker stories?
#163628730


